### PR TITLE
Fix error if the current key table is not ours

### DIFF
--- a/src/wm.ts
+++ b/src/wm.ts
@@ -166,7 +166,9 @@ const getKeys = () => state.keys;
 const getKeyTables = () => state.keyTables;
 const handleRightStatusUpdate = () => {
   wezterm.on("update-right-status", (window) => {
-    window.set_right_status(getModeText(window.active_key_table() ?? "normal"));
+  	const ourPaneText = getModeText(window.active_key_table() ?? "normal");
+  	if (ourPaneText)
+    	window.set_right_status(ourPaneText);
   });
 };
 const mergeTables = mergeObjects;


### PR DESCRIPTION
Right now this throws errors if the key map is not one we set (ie the search key table).   It doesn't actually effect anything because the exception throws you out before you then go to set_right_status to nil.   Specifically only set it now if we know it is ours, to avoid clearing out a last known good status too.